### PR TITLE
Specify postgres version for langfuse deploy

### DIFF
--- a/Langfuse/docker-compose.yml
+++ b/Langfuse/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         - LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES=${LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:-true}
 
   pg-langfuse:
-    image: postgres
+    image: postgres:16
     restart: always
     command: postgres -p 5433
     healthcheck:


### PR DESCRIPTION
Hit an error when trying to deploy langfuse. Need to specify latest stable version of postgres 