### PR TITLE
Switch Postgres container to auto-updating image

### DIFF
--- a/Postgres/docker-compose.yml
+++ b/Postgres/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       - DB_POSTGRESDB_PASSWORD=password
     depends_on:
       - pg-n8n
-      
+
   pg-n8n:
-    image: postgres:12
+    image: pgautoupgrade/pgautoupgrade:latest
     restart: always
     environment:
       - POSTGRES_DB=n8n


### PR DESCRIPTION
Upgrading major versions of Postgres automatically is not supported by
the "default" Docker image and requires either dump + restore
between versions or running two versions simultaneously to use pg_upgrade

This image manages upgrades automatically instead

See: https://github.com/docker-library/postgres/issues/37
